### PR TITLE
Change package name to ps-fuzz and executable name from 'ps_fuzz' to 'prompt_security_fuzzer'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,8 @@ venv
 .env
 __pycache__
 *.egg-info/
-psfuzz.log
-.psfuzz-config.json
+prompt_security_fuzzer.log
+.prompt-security-fuzzer-config.json
 .pytest_cache
 build/
 dist/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
-# Contributing to PS_Fuzz
+# Contributing to Prompt Security Fuzzer
 
-Thank you for your interest in contributing to PS_Fuzz! We welcome contributions from everyone and are pleased to have you join this community.
+Thank you for your interest in contributing to Prompt Security Fuzzer! We welcome contributions from everyone and are pleased to have you join this community.
 This document provides guidelines and instructions for contributing to this project.
 
 ## Code of Conduct
 
-The PS_Fuzz project adheres to a code of conduct that you can read at [Code of Conduct](LINK_TO_CODE_OF_CONDUCT).
+The Prompt Security project adheres to a code of conduct that you can read at [Code of Conduct](LINK_TO_CODE_OF_CONDUCT).
 By participating in this project, you agree to abide by its terms.
 
 ## Getting Started
@@ -22,8 +22,8 @@ Before you begin, ensure you have the following installed:
 
 2. **Clone Your Fork**:
 ```bash
-git clone https://github.com/yourusername/ps_fuzz.git
-cd ps_fuzz
+git clone https://github.com/prompt-security/ps-fuzz.git
+cd ps-fuzz
 ```
 
 ### Set up a virtual environment
@@ -67,15 +67,16 @@ The tool would automatically recognize that the file is present and will try to 
 
 ### Running the Tool
 
-To run the ps_fuzz tool from your development environment, you can use the command-line interface set up in the project.
-Since the package is installed in editable mode, you can run the tool directly from the source code without needing a separate installation step for testing changes.
+To run the tool from your development environment, you can use the command-line interface set up in the project.
+Since the package is installed in editable mode (e.g. via `pip install -e .[dev]`), you can run the tool directly from the source code without
+needing a separate installation step for testing changes.
 
 To execute the tool, use the following command:
 ```bash
-ps_fuzz --help
+prompt_security_fuzzer --help
 ```
 
-or alternatively:
+Or alternatively, execute directly from subdirectory:
 ```bash
 python -m ps_fuzz --help
 ```

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ We use a dynamic testing approach, where we get the necessary context from your 
 ### Usage
 
 ```
-usage: ps_fuzz [-h] [--list-providers] [--list-attacks] [--attack-provider ATTACK_PROVIDER] [--attack-model ATTACK_MODEL] [--target-provider TARGET_PROVIDER] [--target-model TARGET_MODEL]
+usage: prompt_security_fuzzer [-h] [--list-providers] [--list-attacks] [--attack-provider ATTACK_PROVIDER] [--attack-model ATTACK_MODEL] [--target-provider TARGET_PROVIDER] [--target-model TARGET_MODEL]
                [-n NUM_ATTEMPTS] [-t NUM_THREADS] [-a ATTACK_TEMPERATURE] [-d DEBUG_LEVEL] [-b]
                [system_prompt_file]
 
@@ -107,5 +107,5 @@ options:
 ### Example
 Run tests against the system prompt (in non-interactive batch mode):
 ```
-psfuzz.py -b ./system_prompt.examples/medium_system_prompt.txt
+prompt_security_fuzzer.py -b ./system_prompt.examples/medium_system_prompt.txt
 ```

--- a/ps_fuzz/cli.py
+++ b/ps_fuzz/cli.py
@@ -20,7 +20,7 @@ RESET = colorama.Style.RESET_ALL
 BRIGHT = colorama.Style.BRIGHT
 
 # Maintain configuration state in the user's home directory
-APP_CONFIG_FILE = os.path.join(os.path.expanduser("~"), ".psfuzz-config.json")
+APP_CONFIG_FILE = os.path.join(os.path.expanduser("~"), ".prompt-security-fuzzer-config.json")
 
 def main():
     # Print the logo

--- a/ps_fuzz/ps_logging.py
+++ b/ps_fuzz/ps_logging.py
@@ -1,7 +1,7 @@
 import logging
 from logging.handlers import RotatingFileHandler
 
-LOG_FILE_PATH = "psfuzz.log"
+LOG_FILE_PATH = "prompt_security_fuzzer.log"
 
 def setup_logging(debug_level: int):
     # Set up logging with specific debug_level

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     },
     entry_points={
         'console_scripts': [
-            'ps_fuzz=ps_fuzz.cli:main',
+            'prompt_security_fuzzer=ps_fuzz.cli:main',
         ],
     },
 )


### PR DESCRIPTION
Also, the log file changed to `prompt_security_fuzzer.log` and config file to `~/.prompt-security-fuzzer-config.json`.
Also, corrected some instructions in README.md to match the above, as well as improve overall correctness (some suggestions were incorrect there), and make the README.md more clear in general.