### PR TITLE
Make debug level configurable only on command line

### DIFF
--- a/ps_fuzz/app_config.py
+++ b/ps_fuzz/app_config.py
@@ -4,7 +4,6 @@ import sys, os
 import colorama
 from .util import wrap_text
 from .results_table import print_table
-from .ps_logging import setup_logging
 import logging
 logger = logging.getLogger(__name__)
 
@@ -17,8 +16,7 @@ class AppConfig:
         'num_attempts': 3,
         'num_threads': 4,
         'attack_temperature': 0.6,
-        'debug_level': 1,
-        'system_prompt': ''
+        'system_prompt': '',
     }
 
     def __init__(self, config_state_file: str):
@@ -129,17 +127,6 @@ class AppConfig:
     def num_threads(self, value: int):
         if value < 1: raise ValueError("Number of threads must be at least 1")
         self.config_state['num_threads'] = value
-        self.save()
-
-    @property
-    def debug_level(self) -> int:
-        return self.config_state['debug_level']
-
-    @debug_level.setter
-    def debug_level(self, value: int):
-        if not (0 <= value <= 2): raise ValueError("Debug level must be between 0 and 2")
-        self.config_state['debug_level'] = value
-        setup_logging(value) # Update logging level based on configured debug level
         self.save()
 
     @property

--- a/ps_fuzz/cli.py
+++ b/ps_fuzz/cli.py
@@ -5,6 +5,7 @@ import colorama
 from dotenv import load_dotenv
 dotenv_path = os.path.join(os.getcwd(), '.env')
 load_dotenv(dotenv_path)
+from .ps_logging import setup_logging
 from .chat_clients import *
 from .client_config import ClientConfig
 from .attack_config import AttackConfig
@@ -45,6 +46,9 @@ def main():
         for test_name, test_description in [(cls.test_name, cls.test_description) for cls in tests]:
             print(f"  {BRIGHT}{test_name}{RESET}: {test_description}")
         sys.exit(0)
+
+    # Setup debug level (default 1)
+    setup_logging(args.debug_level if args.debug_level is not None else 1)
 
     # Load application config from file (if exists)
     app_config = AppConfig(APP_CONFIG_FILE)

--- a/ps_fuzz/interactive_mode.py
+++ b/ps_fuzz/interactive_mode.py
@@ -53,7 +53,6 @@ class MainMenu:
             ['Fuzzer Configuration', None, FuzzerOptions],
             ['Target LLM Configuration', None, TargetLLMOptions],
             ['Attack LLM Configuration', None, AttackLLMOptions],
-            ['Debug Level', None, DebugOptions],
             ['Show all configuration', show_all_config, MainMenu],
             ['Exit', None, None],
         ]
@@ -97,22 +96,6 @@ class FuzzerOptions:
         ])
         if result is None: return  # Handle prompt cancellation concisely
         state.num_attempts = int(result['num_attempts'])
-        return MainMenu
-
-class DebugOptions:
-    @classmethod
-    def show(cls, state: AppConfig):
-        print("Debug Options: Review and modify the debug log level")
-        print("----------------------------------------------------")
-        result = inquirer.prompt([
-            inquirer.Text('debug_level',
-                message="Debug Level (0-2) (0=warnings and errors; 1 = normal; 2 = verbose)",
-                default=str(state.debug_level),
-                validate=lambda _, x: x.isdigit() and int(x) > 0
-            ),
-        ])
-        if result is None: return  # Handle prompt cancellation concisely
-        state.debug_level = int(result['debug_level'])
         return MainMenu
 
 class TargetLLMOptions:


### PR DESCRIPTION
Only on command line and not in the interactive prompt.
The level is also not persisting now (as other settings are), and defaults to 1 (INFO and above) if not specified.