### PR TITLE
Run CI on all supported python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, '3.x']  # '3.x' will use the latest Python 3 release
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,18 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, '3.x']  # '3.x' will use the latest Python 3 release
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
@@ -32,18 +35,20 @@ jobs:
   build-package:
     needs: build-and-test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.11]  # Only build with the latest stable Python for package release
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
 
       - name: Build package using script
         run: |
           chmod +x ./build_package.sh
           ./build_package.sh
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
       - name: Checkout repository
@@ -35,18 +35,15 @@ jobs:
   build-package:
     needs: build-and-test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.11]  # Only build with the latest stable Python for package release
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.11'
 
       - name: Build package using script
         run: |

--- a/ps_fuzz/chat_clients.py
+++ b/ps_fuzz/chat_clients.py
@@ -2,7 +2,7 @@ from .langchain_integration import get_langchain_chat_models_info
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.outputs.llm_result import LLMResult
 from langchain.schema import BaseMessage, HumanMessage, SystemMessage, AIMessage
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 from abc import ABC, abstractmethod
 import sys
 import logging
@@ -53,7 +53,7 @@ class ClientLangChain(ClientBase):
 # Chat session allows chatting against target client while maintaining state (history buffer)
 class ChatSession:
     "Maintains single conversation, including history, and supports an optional system prompts"
-    def __init__(self, client: ClientBase, system_prompts: List[str] | None = None):
+    def __init__(self, client: ClientBase, system_prompts: Optional[List[str]] = None):
         self.client = client
         self.system_prompts = None
         if system_prompts:

--- a/ps_fuzz/langchain_integration.py
+++ b/ps_fuzz/langchain_integration.py
@@ -1,9 +1,9 @@
 from langchain_core.language_models.chat_models import BaseChatModel
 import langchain.chat_models
-from typing import Any, Dict, get_origin
+from typing import Any, Dict, get_origin, Optional
 import inspect, re
 
-def _get_class_member_doc(cls, param_name: str) -> str | None:
+def _get_class_member_doc(cls, param_name: str) -> Optional[str]:
     lines, _ = inspect.getsourcelines(cls)
     state = 0 # 0=waiting, 1=ready, 2=reading mutliline
     doc_lines = []


### PR DESCRIPTION
Hi, just thought I'd drop a quick improvement to the CI since I had an issue installing the package earlier.

In your `setup.py` you mentioned that the minimum supported Python version is 3.7, but it is actually 3.9 with a few tweaks for typing (included in this PR).

I modified the GHA CI to run on all supported Python versions so you'd know if one of the supported versions is not working :)

I tried to include earlier Python versions such as 3.7 and 3.8, but they failed this CI due to incompatible dependencies version resolutions

for python 3.7 - `ERROR: No matching distribution found for langchain==0.0.353`
python 3.8 - `ERROR: No matching distribution found for pandas==2.2.2`

Since Python 3.7 is EOL anyway, I'd suggest removing support for it by modifying the setup.py

I am looking forward to hearing your thoughts!
Awesome work, happy holidays! :)