### PR TITLE
Implement custom clients in addition to ones supported by ChainLang

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ Alternatively, create a file named `.env` in the current directory and set the `
 | `PROMPTLAYER_API_KEY` |  `PromptLayer` and OpenAI Chat large language models API.|
 | `QIANFAN_AK`, `QIANFAN_SK` |  `Baidu Qianfan` chat models.|
 | `YC_API_KEY` | `YandexGPT` large language models.|
-| _none_ | Local transformers pipeline using `flan-t5-small` |
 </details>
 
 <br/>

--- a/ps_fuzz/chat_clients.py
+++ b/ps_fuzz/chat_clients.py
@@ -1,5 +1,7 @@
 from .langchain_integration import get_langchain_chat_models_info
 import importlib
+import importlib.util
+import os
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.outputs.llm_result import LLMResult
 from langchain.schema import BaseMessage, HumanMessage, SystemMessage, AIMessage
@@ -55,9 +57,17 @@ class ClientLangChain(ClientBase):
 class ClientCustom(ClientBase):
     """Chat model wrapper around a local transformers pipeline"""
     def __init__(self, model_name: str):
-        # Dynamically import the module named after the model_name
-        self.custom_module = importlib.import_module(model_name)
-        self.custom_client = self.custom_module.initialize_client(model_name)
+        module_filename = f"{model_name}.py"
+        if os.path.isfile(module_filename):
+            spec = importlib.util.spec_from_file_location(model_name, module_filename)
+            custom_module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(custom_module)
+            self.custom_module = custom_module
+            logger.info(f"Custom client loaded from file '{module_filename}'")
+        else:
+            self.custom_module = importlib.import_module(model_name)
+            logger.info(f"Custom client loaded from module 'model_name'")
+        self.custom_client = self.custom_module.initialize_client()
 
     def interact(self, history: MessageList, messages: MessageList) -> BaseMessage:
         history += messages

--- a/ps_fuzz/chat_clients.py
+++ b/ps_fuzz/chat_clients.py
@@ -54,24 +54,25 @@ class ClientLangChain(ClientBase):
 # Custom chat client using a lightweight transformers pipeline
 class ClientCustom(ClientBase):
     """Chat model wrapper around a local transformers pipeline"""
-    def __init__(self, model_name: str = custom.MODEL_NAME):
-        self.model_name = model_name
-        self.client = custom.initialize_client(model_name)
+    def __init__(self, model_name: str):
+        self.custom_client = custom.initialize_client(model_name)
 
     def interact(self, history: MessageList, messages: MessageList) -> BaseMessage:
-        # Keep track of conversation history (for compatibility only)
+
+        from loguru import logger
+        logger.debug(f"interact: history={history}")
+        logger.debug(f"interact: messages={messages}")
+
         history += messages
-        system_prompt = ""
-        for msg in history:
-            if isinstance(msg, SystemMessage):
-                system_prompt = msg.content
-                break
-        user_prompt = ""
+        
+        prompt = ""
         for msg in reversed(messages):
             if isinstance(msg, HumanMessage):
-                user_prompt = msg.content
+                prompt = msg.content
                 break
-        response, _ = custom.test_prompt(self.client, self.model_name, system_prompt, user_prompt)
+
+        response, _ = custom.test_prompt(self.custom_client, prompt)
+
         history.append(AIMessage(content=response))
         return response
 

--- a/ps_fuzz/chat_clients.py
+++ b/ps_fuzz/chat_clients.py
@@ -58,11 +58,6 @@ class ClientCustom(ClientBase):
         self.custom_client = custom.initialize_client(model_name)
 
     def interact(self, history: MessageList, messages: MessageList) -> BaseMessage:
-
-        from loguru import logger
-        logger.debug(f"interact: history={history}")
-        logger.debug(f"interact: messages={messages}")
-
         history += messages
         
         prompt = ""
@@ -71,7 +66,7 @@ class ClientCustom(ClientBase):
                 prompt = msg.content
                 break
 
-        response, _ = custom.test_prompt(self.custom_client, prompt)
+        response = custom.generate(self.custom_client, prompt)
 
         history.append(AIMessage(content=response))
         return response

--- a/ps_fuzz/chat_clients.py
+++ b/ps_fuzz/chat_clients.py
@@ -1,5 +1,5 @@
 from .langchain_integration import get_langchain_chat_models_info
-from . import custom
+import importlib
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.outputs.llm_result import LLMResult
 from langchain.schema import BaseMessage, HumanMessage, SystemMessage, AIMessage
@@ -55,7 +55,9 @@ class ClientLangChain(ClientBase):
 class ClientCustom(ClientBase):
     """Chat model wrapper around a local transformers pipeline"""
     def __init__(self, model_name: str):
-        self.custom_client = custom.initialize_client(model_name)
+        # Dynamically import the module named after the model_name
+        self.custom_module = importlib.import_module(model_name)
+        self.custom_client = self.custom_module.initialize_client(model_name)
 
     def interact(self, history: MessageList, messages: MessageList) -> BaseMessage:
         history += messages
@@ -66,7 +68,7 @@ class ClientCustom(ClientBase):
                 prompt = msg.content
                 break
 
-        response = custom.generate(self.custom_client, prompt)
+        response = self.custom_module.generate(self.custom_client, prompt)
 
         history.append(AIMessage(content=response))
         return response

--- a/ps_fuzz/chat_clients.py
+++ b/ps_fuzz/chat_clients.py
@@ -59,7 +59,7 @@ class ClientCustom(ClientBase):
 
     def interact(self, history: MessageList, messages: MessageList) -> BaseMessage:
         history += messages
-        
+
         prompt = ""
         for msg in reversed(messages):
             if isinstance(msg, HumanMessage):

--- a/ps_fuzz/cli.py
+++ b/ps_fuzz/cli.py
@@ -37,7 +37,7 @@ def main():
         print("Available providers:")
         for provider_name, provider_info in get_langchain_chat_models_info().items():
             print(f"  {BRIGHT}{provider_name}{RESET}: {provider_info.short_doc}")
-        print(f"  {BRIGHT}custom{RESET}: Custom local transformers pipeline")
+        print(f"  {BRIGHT}custom{RESET}: Custom provider")
         sys.exit(0)
 
     if args.list_attacks:

--- a/ps_fuzz/custom.py
+++ b/ps_fuzz/custom.py
@@ -1,5 +1,6 @@
 from transformers import pipeline
-from loguru import logger
+import logging
+logger = logging.getLogger(__name__)
 
 # Sample custom LLM integration using a lightweight model
 

--- a/ps_fuzz/custom.py
+++ b/ps_fuzz/custom.py
@@ -5,36 +5,19 @@ from loguru import logger
 
 MODEL_NAME = "google/flan-t5-small"
 
-
-def validate_api_keys():
-    """Custom models typically run locally and do not require API keys."""
-    return True
-
-
 def initialize_client(model_name: str):
     """Initialize a text2text-generation pipeline for instruction-tuned models."""
     return pipeline("text2text-generation", model=MODEL_NAME)
 
 
-def test_prompt(client, model: str, system_prompt: str, user_prompt: str):
+def test_prompt(client, model: str, prompt: str):
     """Generate a response using the provided pipeline."""
     try:
-        prompt = f"{system_prompt}\n{user_prompt}" if system_prompt else user_prompt
         result = client(prompt, max_new_tokens=100)
         generated_text = result[0]["generated_text"]
         response = generated_text.strip()
-        logger.info(f"User Prompt: {user_prompt}")
+        logger.debug(f"Prompt: {prompt}")
         logger.debug(f"Generated text: {response}")
         return response, False
     except Exception as exc:
         return f"Error: {exc}", True
-
-
-def validate_model(model_name: str) -> bool:
-    """Check whether the model can be loaded."""
-    try:
-        pipeline("text-generation", model=MODEL_NAME)
-        return True
-    except Exception as exc:
-        print(f"Error loading model {MODEL_NAME}: {exc}")
-        return False

--- a/ps_fuzz/custom.py
+++ b/ps_fuzz/custom.py
@@ -10,14 +10,11 @@ def initialize_client(model_name: str):
     return pipeline("text2text-generation", model=MODEL_NAME)
 
 
-def test_prompt(client, model: str, prompt: str):
+def generate(client, prompt: str):
     """Generate a response using the provided pipeline."""
-    try:
-        result = client(prompt, max_new_tokens=100)
-        generated_text = result[0]["generated_text"]
-        response = generated_text.strip()
-        logger.debug(f"Prompt: {prompt}")
-        logger.debug(f"Generated text: {response}")
-        return response, False
-    except Exception as exc:
-        return f"Error: {exc}", True
+    result = client(prompt, max_new_tokens=100)
+    generated_text = result[0]["generated_text"]
+    response = generated_text.strip()
+    logger.debug(f"Prompt: {prompt}")
+    logger.debug(f"Generated text: {response}")
+    return response

--- a/ps_fuzz/custom.py
+++ b/ps_fuzz/custom.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 MODEL_NAME = "google/flan-t5-small"
 
-def initialize_client(model_name: str):
+def initialize_client():
     """Initialize a text2text-generation pipeline for instruction-tuned models."""
     return pipeline("text2text-generation", model=MODEL_NAME)
 

--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,7 @@ setup(
         "pandas==2.2.2",
         "inquirer==3.2.4",
         "prompt-toolkit==3.0.43",
-        "fastparquet==2024.2.0",
-        "transformers==4.38.2",
-        "loguru==0.7.2"
+        "fastparquet==2024.2.0"
     ],
     extras_require={
         "dev": ["pytest==7.4.4"]


### PR DESCRIPTION
I have customised your tool to add an option to target arbitrary LLM implementations, not only ones supported by LangChains. I have done this to be able to target an LLM exposed via a custom REST API.

To use this mode user has to provide a custom python module implementing two methods. Please see ps_fuzz/custom.py for sample implementation (it uses a local transformer-based model for testing).

To test: prompt-security-fuzzer --target-provider custom --target-model ps_fuzz.custom -b

If you find it useful and willing to merge in -- please let me know. I will adjust README and provide sample client for REST API.