### PR TITLE
PROE-2074: Fix broken ps-fuzz dependency causing crashes due to non-pinned httpx library version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     ],
     python_requires='>=3.7',
     install_requires=[
+        "httpx>=0.24.0,<0.25.0",
         "openai==1.6.1",
         "langchain==0.0.353",
         "langchain-community==0.0.7",


### PR DESCRIPTION
**Bug description**

The `httpx` library's interface broke over time, and it was not pinned in the setup.py dependencies list.

**The fix**
The fix is to pin it to a compatible version.

Original crash was:
```python
  File "~/work/oss-contributions/ps-fuzz/venv/bin/prompt-security-fuzzer", line 8, in <module>
    sys.exit(main())
  File "~/work/oss-contributions/ps-fuzz/ps_fuzz/cli.py", line 65, in main
    interactive_shell(app_config)
  File "~/work/oss-contributions/ps-fuzz/ps_fuzz/interactive_mode.py", line 153, in interactive_shell
    stage = stage.show(state)
  File "~/work/oss-contributions/ps-fuzz/ps_fuzz/interactive_mode.py", line 69, in show
    if func: func(state)
  File "~/work/oss-contributions/ps-fuzz/ps_fuzz/prompt_injection_fuzzer.py", line 177, in run_fuzzer
    target_client = ClientLangChain(app_config.target_provider, model=app_config.target_model, temperature=0)
  File "~/work/oss-contributions/ps-fuzz/ps_fuzz/chat_clients.py", line 38, in __init__
    self.client = chat_models_info[backend].model_cls(**kwargs)
  File "~/work/oss-contributions/ps-fuzz/venv/lib/python3.13/site-packages/langchain_core/load/serializable.py", line 107, in __init__
    super().__init__(**kwargs)
  File "~/work/oss-contributions/ps-fuzz/venv/lib/python3.13/site-packages/pydantic/v1/main.py", line 352, in __init__
    raise validation_error
pydantic.v1.error_wrappers.ValidationError: 1 validation error for ChatOpenAI __root__
  Client.__init__() got an unexpected keyword argument 'proxies' (type=type_error)
```

The fix is to pin the httpx version in `setup.py`.