### PR TITLE
Fix results table headers

### DIFF
--- a/ps_fuzz/results_table.py
+++ b/ps_fuzz/results_table.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
 
     print_table(
         title = "Test results simulated",
-        headers = ["", "Test", "Succesful", "Unsuccesful", "Score (1-10)"],
+        headers = ["", "Test", "Successful", "Unsuccessful", "Score (1-10)"],
         data = [
             [ PASSED, "Test 1 (good)", 1, 0, 10 ],
             [ FAILED, "Test 2 (bad)", 0, 1, 0 ],
@@ -49,7 +49,7 @@ if __name__ == "__main__":
 
     print_table(
         title = "Test results simulated with footer",
-        headers = ["", "Test", "Succesful", "Unsuccesful", "Score (1-10)"],
+        headers = ["", "Test", "Successful", "Unsuccessful", "Score (1-10)"],
         data = [
             [ PASSED, "Test 1 (good)", 1, 0, 10 ],
             [ FAILED, "Test 2 (bad)", 0, 1, 0 ],


### PR DESCRIPTION
# User description
## Summary
- Fix the misspelled `Succesful` and `Unsuccesful` headers in the simulated results table output.
- Apply the correction to both sample tables in `ps_fuzz/results_table.py`.

## Source proof
Before this change, `ps_fuzz/results_table.py` used `Succesful` and `Unsuccesful` in both demo header lists.

## Duplicate check
Repo-scoped PR/issue searches were run before editing and again immediately before opening this PR:
- `gh search prs 'Succesful' --repo prompt-security/ps-fuzz` only found closed PR #67, which did not touch `ps_fuzz/results_table.py`.
- `gh search prs 'Unsuccesful' --repo prompt-security/ps-fuzz` returned no results.
- `gh search prs 'successful header results_table' --repo prompt-security/ps-fuzz` returned no results.
- `gh search issues 'Succesful Unsuccesful' --repo prompt-security/ps-fuzz` returned no results.

## Verification
- RED before the fix: a source assertion requiring `"Successful"` and `"Unsuccessful"` failed with `AssertionError`.
- GREEN after the fix: the same source assertion passed and confirmed the misspelled forms are absent.
- `python3 -m compileall -q ps_fuzz/results_table.py`
- `python ps_fuzz/results_table.py` in a temp venv with `colorama==0.4.6` and `prettytable==3.10.0`; output contains `Successful` and `Unsuccessful` in both tables.
- `git diff --check`

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Fix the simulated results tables in <code>ps_fuzz.results_table</code> to display <code>Successful</code> and <code>Unsuccessful</code> headers instead of the previous misspellings. Maintain the sample tables generated by <code>print_table</code> so their scoring layout remains consistent while the header strings align with the expected values.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
<sub><a href="https://baz.co/changes/prompt-security/ps-fuzz/74?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>