### PR TITLE
Fix empty provider list from lazy langchain_community exports

### DIFF
--- a/ps_fuzz/langchain_integration.py
+++ b/ps_fuzz/langchain_integration.py
@@ -87,7 +87,10 @@ def get_langchain_chat_models_info() -> Dict[str, Dict[str, Any]]:
     models: Dict[str, ChatModelInfo] = {}
     for model_cls_name in chat_models_module.__all__:
         if model_cls_name in EXCLUDED_CHAT_MODELS: continue
-        model_cls = chat_models_module.__dict__.get(model_cls_name)
+        try:
+            model_cls = getattr(chat_models_module, model_cls_name, None)
+        except Exception:
+            continue
         if model_cls and issubclass(model_cls, BaseChatModel):
             model_short_name = camel_to_snake(model_cls.__name__).replace('_chat', '').replace('chat_', '')
             # Introspect supported model parameters

--- a/ps_fuzz/langchain_integration.py
+++ b/ps_fuzz/langchain_integration.py
@@ -2,6 +2,9 @@ from langchain_core.language_models.chat_models import BaseChatModel
 import langchain_community.chat_models as chat_models_module
 from typing import Any, Dict, get_origin, Optional
 import inspect, re
+import logging
+
+logger = logging.getLogger(__name__)
 
 def _get_class_member_doc(cls, param_name: str) -> Optional[str]:
     lines, _ = inspect.getsourcelines(cls)
@@ -89,7 +92,8 @@ def get_langchain_chat_models_info() -> Dict[str, Dict[str, Any]]:
         if model_cls_name in EXCLUDED_CHAT_MODELS: continue
         try:
             model_cls = getattr(chat_models_module, model_cls_name, None)
-        except Exception:
+        except Exception as e:
+            logger.warning(f"Skipping chat model '{model_cls_name}': {e}")
             continue
         if model_cls and issubclass(model_cls, BaseChatModel):
             model_short_name = camel_to_snake(model_cls.__name__).replace('_chat', '').replace('chat_', '')

--- a/tests/test_chat_clients.py
+++ b/tests/test_chat_clients.py
@@ -1,7 +1,7 @@
 import os, sys
 sys.path.append(os.path.abspath('.'))
 from unittest.mock import patch, MagicMock
-from ps_fuzz.chat_clients import ClientBase, ClientLangChain, MessageList, BaseMessage, SystemMessage, HumanMessage, AIMessage
+from ps_fuzz.chat_clients import ClientBase, ClientLangChain, MessageList, BaseMessage, SystemMessage, HumanMessage, AIMessage, chat_models_info
 from ps_fuzz.langchain_integration import ChatModelParams, ChatModelInfo
 from ps_fuzz.attack_config import AttackConfig
 from ps_fuzz.client_config import ClientConfig
@@ -41,6 +41,15 @@ def test_client_langchain():
     ]
     result = client_langchain.interact(history = fake_history, messages = [])
     assert result == "fakeresponse: model_name='fake-model-turbo'; temperature=0.123; messages_count=2"
+
+
+def test_chat_models_info_is_populated():
+    # Unmocked, unlike every other test in this file -- guards the real
+    # chat_models_info module attribute (chat_clients.py:15) itself, which the
+    # other tests all patch over and so would never catch going empty again.
+    assert len(chat_models_info) > 0
+    assert 'open_ai' in chat_models_info
+    assert 'anthropic' in chat_models_info
 
 
 class TestClientLangChainBaseURL:

--- a/tests/test_langchain_integration.py
+++ b/tests/test_langchain_integration.py
@@ -14,6 +14,14 @@ def test_get_langchain_chat_models_info_returns_non_empty():
 
 
 def test_get_langchain_chat_models_info_resolves_lazy_getattr_exports():
+    # get_langchain_chat_models_info() must resolve chat model classes via
+    # getattr(), not module.__dict__: langchain_community.chat_models exports its
+    # classes lazily, listing 63 names in __all__ but only resolving each one
+    # through a module-level __getattr__ (PEP 562) -- they're never stored in the
+    # module's __dict__. Reading __dict__ directly would silently resolve every
+    # class to None. This test reproduces that lazy-export mechanism with a
+    # minimal fake module, independent of langchain_community's actual
+    # (changeable) internals.
     class FakeModel(BaseChatModel):
         @property
         def _llm_type(self) -> str:
@@ -23,8 +31,13 @@ def test_get_langchain_chat_models_info_resolves_lazy_getattr_exports():
             return ChatResult(generations=[ChatGeneration(message=AIMessage(content="ok"))])
 
     fake_module = types.ModuleType("fake_chat_models_module")
+    # get_langchain_chat_models_info() loops over __all__ to know which names to
+    # look up -- it's just candidate names, not a way to access them directly.
     fake_module.__all__ = ["FakeModel"]
 
+    # FakeModel is deliberately never placed in fake_module.__dict__, only reachable
+    # via __getattr__ -- this is what makes fake_module.__dict__.get("FakeModel")
+    # return None while getattr(fake_module, "FakeModel", None) resolves it.
     def __getattr__(name):
         if name == "FakeModel":
             return FakeModel
@@ -32,8 +45,13 @@ def test_get_langchain_chat_models_info_resolves_lazy_getattr_exports():
 
     fake_module.__getattr__ = __getattr__
 
+    # Patch by usage site (ps_fuzz.langchain_integration.chat_models_module), not
+    # definition site (langchain_community.chat_models) -- patch() replaces the name
+    # as looked up inside langchain_integration.py, without touching the real library
+    # for any other consumer. Restored automatically once the `with` block exits.
     with patch("ps_fuzz.langchain_integration.chat_models_module", fake_module):
         models = get_langchain_chat_models_info()
 
+    assert len(models) == 1
     assert "fake_model" in models
     assert models["fake_model"].model_cls is FakeModel

--- a/tests/test_langchain_integration.py
+++ b/tests/test_langchain_integration.py
@@ -1,0 +1,39 @@
+import os, sys
+sys.path.append(os.path.abspath('.'))
+import types
+from unittest.mock import patch
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.outputs import ChatResult, ChatGeneration
+from langchain_core.messages import AIMessage
+from ps_fuzz.langchain_integration import get_langchain_chat_models_info
+
+
+def test_get_langchain_chat_models_info_returns_non_empty():
+    models = get_langchain_chat_models_info()
+    assert models, "expected at least one chat model to be discovered from langchain_community.chat_models"
+
+
+def test_get_langchain_chat_models_info_resolves_lazy_getattr_exports():
+    class FakeModel(BaseChatModel):
+        @property
+        def _llm_type(self) -> str:
+            return "fake_model"
+
+        def _generate(self, messages, **kwargs) -> ChatResult:
+            return ChatResult(generations=[ChatGeneration(message=AIMessage(content="ok"))])
+
+    fake_module = types.ModuleType("fake_chat_models_module")
+    fake_module.__all__ = ["FakeModel"]
+
+    def __getattr__(name):
+        if name == "FakeModel":
+            return FakeModel
+        raise AttributeError(name)
+
+    fake_module.__getattr__ = __getattr__
+
+    with patch("ps_fuzz.langchain_integration.chat_models_module", fake_module):
+        models = get_langchain_chat_models_info()
+
+    assert "fake_model" in models
+    assert models["fake_model"].model_cls is FakeModel


### PR DESCRIPTION
> **Note:** [#72](https://github.com/prompt-security/ps-fuzz/pull/72) also resolves this via a broader dependency modernization — see comment for details on the overlap/tradeoffs.

# User description
## Summary

- `get_langchain_chat_models_info()` read `chat_models_module.__dict__.get(name)` directly, which bypasses `langchain_community.chat_models`'s lazy `__getattr__`-based exports (PEP 562) — every class always resolved to `None`, so provider discovery silently returned `{}`.
- This broke `--list-providers`, the interactive TUI's Target/Attack LLM provider menus, and instantiating any real (non-test-mocked) LangChain backend via `ClientLangChain`.
- Regression from `17f2502` ("Fix critical and high severity Dependabot vulnerabilities (#70)"), which correctly bumped `langchain-community` to fix CVE-2025-68664 and moved the import from `langchain.chat_models` to `langchain_community.chat_models`, but didn't account for the newer package's lazy-loading mechanism. Uncaught for ~5 months because the existing test suite mocks `chat_models_info` entirely and never exercised the real discovery function.
- Fix: use `getattr(chat_models_module, model_cls_name, None)` so the lazy loader actually fires, wrapped in try/except so one broken lazy import can't crash the whole CLI at startup, with a `logger.warning` if that ever happens.

## Testing

- Added `tests/test_langchain_integration.py`: a real-library regression test (now discovers 59 providers, was 0) and a synthetic test reproducing the exact lazy-`__getattr__` mechanism, decoupled from `langchain_community`'s actual internals.
- Added a test to `tests/test_chat_clients.py` guarding the real (unmocked) `chat_models_info` module attribute, since every existing test there patches it with a fake dict.
- Full suite passes: 96 passed.

## Test plan

- [x] `pytest` — full suite green
- [x] `python -m ps_fuzz.cli --list-providers` — prints real provider names, not just the header
- [x] `python3 -c "from ps_fuzz.langchain_integration import get_langchain_chat_models_info; print(len(get_langchain_chat_models_info()))"` — returns 59, was 0

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Fix provider discovery in <code>ps_fuzz.langchain_integration</code> so <code>ClientLangChain</code> and the CLI menus can enumerate real LangChain chat backends again. Add regression coverage for lazy <code>langchain_community.chat_models</code> exports and the <code>chat_models_info</code> wiring.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/ps-fuzz/75?tool=ast&topic=Provider+discovery>Provider discovery</a>
        </td><td>Resolve chat model classes with <code>getattr()</code> so lazy <code>langchain_community.chat_models</code> exports are discovered instead of returning an empty provider list.<details><summary>Modified files (1)</summary><ul><li>ps_fuzz/langchain_integration.py</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/ps-fuzz/75?tool=ast&topic=Regression+tests>Regression tests</a>
        </td><td>Add regression tests that exercise real model discovery, lazy <code>__getattr__</code> exports, and the unmocked <code>chat_models_info</code> cache used by <code>ClientLangChain</code>.<details><summary>Modified files (2)</summary><ul><li>tests/test_chat_clients.py</li>
<li>tests/test_langchain_integration.py</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/prompt-security/ps-fuzz/75?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>